### PR TITLE
Fix trailing empty page in print layout

### DIFF
--- a/_sass/_cv.scss
+++ b/_sass/_cv.scss
@@ -98,6 +98,20 @@
   
   /* Print optimizations for PDF generation */
   @media print {
+    /* Remove container margins/padding that cause empty trailing pages */
+    body, html {
+      margin: 0;
+      padding: 0;
+      background: #fff;
+    }
+    
+    .cv-container {
+      margin: 0;
+      padding: 0;
+      box-shadow: none;
+      max-width: 100%;
+    }
+
     .download-btn {
       display: none;
     }


### PR DESCRIPTION
Removes body/container margins and padding in the print media query that often push an invisible box onto a final blank page during PDF generation.