### PR TITLE
Fix trailing empty page (remove wrapper padding)

### DIFF
--- a/_sass/_cv.scss
+++ b/_sass/_cv.scss
@@ -100,20 +100,25 @@
   @media print {
     /* Remove container margins/padding that cause empty trailing pages */
     body, html {
-      margin: 0;
-      padding: 0;
+      margin: 0 !important;
+      padding: 0 !important;
       background: #fff;
     }
     
+    /* Target the Jekyll page wrapper to strip its padding too */
+    .page-content {
+      padding: 0 !important;
+    }
+    
     .cv-container {
-      margin: 0;
-      padding: 0;
-      box-shadow: none;
-      max-width: 100%;
+      margin: 0 !important;
+      padding: 0 !important;
+      box-shadow: none !important;
+      max-width: 100% !important;
     }
 
     .download-btn {
-      display: none;
+      display: none !important;
     }
 
     /* Prevent page breaks inside a job entry */


### PR DESCRIPTION
The previous fix removed margins on the body and inner container, but the Jekyll theme wrapper `.page-content` still had padding that was pushing an invisible box onto the next page when printed. This forces all container padding/margins to 0 during PDF export.